### PR TITLE
fix: Update Scalingo address to include utm tags

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -103,7 +103,7 @@ export default function Footer({ mt = 5 }) {
         © 2023 The Shift Project. All rights reserved.
       </Copyright>
       <Copyright fontSize={3} color="darkBlue" marginBottom={2}>
-        Graciously hosted by <Link href="https://scalingo.com">Scalingo</Link> in 🇫🇷
+        Graciously hosted by <Link href="https://scalingo.com?utm_source=referral&utm_medium=website-footer&utm_campaign=shiftproject">Scalingo</Link> in 🇫🇷
       </Copyright>
     </FooterEl>
   )


### PR DESCRIPTION
Scalingo asked us if we could add the utm tags on the link. 